### PR TITLE
Bump to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -9,7 +8,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 5.4
     - php: 7.0
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "MIT"
   ],
   "require" : {
+    "php":  ">=5.5"
     "league/tactician": "^0.3"
   },
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "MIT"
   ],
   "require" : {
-    "php":  ">=5.5"
+    "php":  ">=5.5",
     "league/tactician": "^0.3"
   },
   "autoload" : {


### PR DESCRIPTION
Tactician is 5.5+ so this bundle should follow in suit.

Adjusted composer.json and travis config.
