### PR TITLE
Upgrade to Tactician 0.5

### DIFF
--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -34,16 +34,15 @@ class ContainerBasedHandlerLocator implements HandlerLocator
     /**
      * Retrieves the handler for a specified command
      *
-     * @param Command $command
+     * @param string $commandName
      * @return mixed
      */
-    public function getHandlerForCommand(Command $command)
+    public function getHandlerForCommand($commandName)
     {
-        $commandClass = get_class($command);
-        if (!isset($this->commandToServiceId[$commandClass])) {
-            throw MissingHandlerException::forCommand($command);
+        if (!isset($this->commandToServiceId[$commandName])) {
+            throw MissingHandlerException::forCommand($commandName);
         }
 
-        return $this->container->get($this->commandToServiceId[$commandClass]);
+        return $this->container->get($this->commandToServiceId[$commandName]);
     }
 }

--- a/Handler/ContainerBasedHandlerLocator.php
+++ b/Handler/ContainerBasedHandlerLocator.php
@@ -1,7 +1,6 @@
 <?php
 namespace Xtrasmal\TacticianBundle\Handler;
 
-use League\Tactician\Command;
 use League\Tactician\Exception\MissingHandlerException;
 use League\Tactician\Handler\Locator\HandlerLocator;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/Middleware/ValidatorMiddleware.php
+++ b/Middleware/ValidatorMiddleware.php
@@ -2,7 +2,6 @@
 
 namespace Xtrasmal\TacticianBundle\Middleware;
 
-use League\Tactician\Command;
 use League\Tactician\Middleware;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -21,13 +20,13 @@ class ValidatorMiddleware implements Middleware
     }
 
     /**
-     * @param Command|object $command
+     * @param object $command
      * @param callable $next
      * @return mixed
      * @throws InvalidCommandException
      * @throws \Exception
      */
-    public function execute(Command $command, callable $next)
+    public function execute($command, callable $next)
     {
         if ($this->validator === null) {
             throw new \Exception(

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -14,6 +14,7 @@ services:
     tactician.middleware.command_handler:
         class: League\Tactician\Handler\CommandHandlerMiddleware
         arguments:
+            - @tactician.handler.command_name_extractor.class_name
             - @tactician.handler.locator.symfony
             - @tactician.handler.method_name_inflector.handle
 
@@ -35,3 +36,9 @@ services:
     tactician.handler.method_name_inflector.invoke:
         class: League\Tactician\Handler\MethodNameInflector\InvokeInflector
 
+    # The CommandNameExtractors in Tactician core
+    tactician.handler.command_name_extractor.class_name:
+        class: League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor
+
+    tactician.plugins.named_command.extractor:
+        class: League\Tactician\Plugins\NamedCommand\NamedCommandExtractor

--- a/Tests/Fake/FakeCommand.php
+++ b/Tests/Fake/FakeCommand.php
@@ -1,0 +1,9 @@
+<?php
+namespace Xtrasmal\TacticianBundle\Tests\Fake;
+
+/**
+ * A mock command used in unit testing this bundle
+ */
+class FakeCommand
+{
+}

--- a/Tests/Middleware/ValidatorMiddlewareTest.php
+++ b/Tests/Middleware/ValidatorMiddlewareTest.php
@@ -1,20 +1,16 @@
 <?php
-
-
 namespace Xtrasmal\TacticianBundle\Tests\Middleware;
 
-
-use League\Tactician\Command;
 use Mockery\MockInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Xtrasmal\TacticianBundle\Middleware\InvalidCommandException;
 use Xtrasmal\TacticianBundle\Middleware\ValidatorMiddleware;
+use Xtrasmal\TacticianBundle\Tests\Fake\FakeCommand;
 
 class ValidatorMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var ValidatorInterface | MockInterface
      */
@@ -37,28 +33,28 @@ class ValidatorMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testExecute()
     {
         $list = new ConstraintViolationList([\Mockery::mock('Symfony\Component\Validator\ConstraintViolation')]);
-        $command = \Mockery::mock('League\Tactician\Command');
 
         $this->validator->shouldReceive('validate')->once()->andReturn($list);
 
         try {
 
-            $this->middleware->execute($command, function () {});
+            $this->middleware->execute(new FakeCommand(), function () {
+            });
 
         } catch (InvalidCommandException $e) {
             $this->assertEquals($list, $e->getViolations());
-            $this->assertEquals($command, $e->getCommand());
+            $this->assertEquals(new FakeCommand(), $e->getCommand());
         }
     }
 
     public function testExecuteWithoutViolations()
     {
         $list = new ConstraintViolationList([]);
-        $command = \Mockery::mock('League\Tactician\Command');
 
         $this->validator->shouldReceive('validate')->once()->andReturn($list);
 
-        $this->middleware->execute($command, function () {});
+        $this->middleware->execute(new FakeCommand(), function () {
+        });
     }
 
     /**
@@ -67,6 +63,7 @@ class ValidatorMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testExecuteWithoutValidator()
     {
         $this->middleware = new ValidatorMiddleware();
-        $this->middleware->execute(\Mockery::mock('League\Tactician\Command'), function () {});
+        $this->middleware->execute(new FakeCommand(), function () {
+        });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require" : {
     "php":  ">=5.5",
-    "league/tactician": "^0.3"
+    "league/tactician": "^0.5"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "327c027513a32ebce92e77ff4086294e",
+    "hash": "41fb70461e66fd3d7cdd874cde736af0",
     "packages": [
         {
             "name": "league/tactician",
-            "version": "v0.3.0",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/tactician.git",
-                "reference": "c41b6c5e80ebb12e0efba204a8293b435297071c"
+                "reference": "69d82bd7e554139e0f1ffc749534757a40967662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/tactician/zipball/c41b6c5e80ebb12e0efba204a8293b435297071c",
-                "reference": "c41b6c5e80ebb12e0efba204a8293b435297071c",
+                "url": "https://api.github.com/repos/thephpleague/tactician/zipball/69d82bd7e554139e0f1ffc749534757a40967662",
+                "reference": "69d82bd7e554139e0f1ffc749534757a40967662",
                 "shasum": ""
             },
             "require": {
@@ -26,12 +26,12 @@
             "require-dev": {
                 "mockery/mockery": "~0.9",
                 "phpunit/phpunit": "~4.3",
-                "squizlabs/php_codesniffer": "~2.0"
+                "squizlabs/php_codesniffer": "~2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.4-dev"
+                    "dev-master": "0.6-dev"
                 }
             },
             "autoload": {
@@ -55,7 +55,7 @@
                 "command bus",
                 "service layer"
             ],
-            "time": "2015-02-12 15:03:11"
+            "time": "2015-04-04 16:44:49"
         }
     ],
     "packages-dev": [
@@ -1893,6 +1893,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.5"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
This PR does everything necessary to upgrade from Tactician 0.3 to 0.5, which is pretty swell.

There is one thing this PR can't do: you'll need to strip all references to the `League\Tactician\Command` interface in your app as it was removed in 0.4. Sorry for the inconvenience!
