### PR TITLE
Support multiple command buses

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,10 +22,22 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('tactician');
         $rootNode
             ->children()
-                ->arrayNode('middlewares')
+                ->scalarNode('default_bus')
+                    ->defaultValue('default')
+                    ->cannotBeEmpty()
+                ->end()
+                ->arrayNode('commandbus')
+                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
-                    ->defaultValue(['tactician.middleware.command_handler'])
-                    ->prototype('scalar')->end()
+                    ->prototype('array')
+                        ->children()
+                            ->arrayNode('middleware')
+                                ->useAttributeAsKey('name')
+                                ->prototype('scalar')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->defaultValue(['default' => ['middleware' => ['tactician.middleware.command_handler']]])
                 ->end()
             ->end();
         return $treeBuilder;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * This is the class that validates and merges configuration from your app/config files
@@ -10,7 +11,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-
     /**
      * Create a rootnode tree for configuration that can be injected into the DI container
      *
@@ -20,26 +20,55 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('tactician');
+
         $rootNode
             ->children()
-                ->scalarNode('default_bus')
-                    ->defaultValue('default')
-                    ->cannotBeEmpty()
-                ->end()
                 ->arrayNode('commandbus')
+                    ->defaultValue(['default' => ['middleware' => ['tactician.middleware.command_handler']]])
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
                             ->arrayNode('middleware')
+                                ->requiresAtLeastOneElement()
                                 ->useAttributeAsKey('name')
                                 ->prototype('scalar')->end()
                             ->end()
                         ->end()
                     ->end()
-                    ->defaultValue(['default' => ['middleware' => ['tactician.middleware.command_handler']]])
                 ->end()
-            ->end();
+                ->scalarNode('default_bus')
+                    ->defaultValue('default')
+                    ->cannotBeEmpty()
+                ->end()
+            ->end()
+            ->validate()
+                ->ifTrue(function($config) {
+                    return is_array($config) &&
+                        array_key_exists('default_bus', $config) &&
+                        array_key_exists('commandbus', $config)
+                    ;
+                })
+                    ->then(function($config) {
+                        $busNames = [];
+                        foreach ($config['commandbus'] as $busName => $busConfig) {
+                            $busNames[] = $busName;
+                        }
+
+                        if (!in_array($config['default_bus'], $busNames)) {
+                            throw new InvalidConfigurationException(
+                                sprintf(
+                                    'The default_bus "%s" was not defined as command bus. Valid option(s): %s',
+                                    $config['default_bus'],
+                                    implode(', ', $busNames)
+                                )
+                            );
+                        }
+                        return $config;
+                    })
+            ->end()
+        ;
+
         return $treeBuilder;
 
     }

--- a/README.md
+++ b/README.md
@@ -57,21 +57,60 @@ The tag should have two attributes: the tag name, which should always be `tactic
 Everything inside Tactician is a middleware plugin. Without any middleware configured, nothing will happen when you pass a command to `handle()`.
 
 By default, the only Middleware enabled is the Command Handler support. You can override this and add your own middleware in the `app/config.yml`.
-    
+
 ```yaml
 
-   tactician:
-       middlewares:
-         # service ids for all your middlewares, top down. First in, first out.
-         - tactician.middleware.locking
-         - my.custom.middleware.plugin
-         - tactician.middleware.command_handler
+  tactician:
+    commandbus:
+      default:
+        middleware:
+          # service ids for all your middlewares, top down. First in, first out.
+          - tactician.middleware.locking
+          - my.custom.middleware.plugin
+          - tactician.middleware.command_handler
 
 ```
 
 **Important**: Adding your own middleware is absolutely encouraged, just be sure to always add `tactician.middleware.command_handler` as the final middleware. Otherwise, your commands won't actually be executed.
 
-Check the [Tactician docs](http://tactician.thephpleague.com/) for more info and a complete list of middleware. 
+Check the [Tactician docs](http://tactician.thephpleague.com/) for more info and a complete list of middleware.
+
+## Configuring Command buses
+The bundle is pre-configured with a command bus called "default". Which has the service name `tactician.commandbus`.
+Some users want to configure more than one command bus though. You can do this via configuration, like so:
+
+```yaml
+
+  tactician:
+    commandbus:
+      default:
+        middleware:
+          - tactician.middleware.command_handler
+      queued:
+        middleware:
+          - tactician.middleware.queued_command_handler
+
+```
+
+The configuration defines two buses: "default" and "queued". These buses will be registered as the
+`tactician.commandbus.default` and `tactician.commandbus.queued` services respectively.
+
+If you want, you can also change which command handler is registered under `tactician.commandbus`. You can do this by
+setting the `default_bus` value in the configuration, like so:
+
+```yaml
+
+  tactician:
+    default_bus: queued
+    commandbus:
+      default:
+        middleware:
+          # ...
+      queued:
+        middleware:
+          # ...
+
+```
 
 ### Extra Bundled Middleware
 

--- a/Resources/config/services/services.yml
+++ b/Resources/config/services/services.yml
@@ -2,9 +2,6 @@ parameters:
   tactician.commandbus.class: League\Tactician\CommandBus
 
 services:
-    tactician.commandbus:
-        class: %tactician.commandbus.class%
-
     tactician.handler.locator.symfony:
         class: Xtrasmal\TacticianBundle\Handler\ContainerBasedHandlerLocator
         arguments:

--- a/TacticianBundle.php
+++ b/TacticianBundle.php
@@ -17,5 +17,4 @@ class TacticianBundle extends Bundle
     {
         return new TacticianExtension();
     }
-
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -28,9 +28,13 @@ class ConfigurationTest extends AbstractConfigurationTestCase
     {
         $this->assertConfigurationIsValid([
             'tactician' => [
-                'middlewares' => [
-                    'my_middleware'  => 'some_middleware',
-                    'my_middleware2' => 'some_middleware',
+                'commandbus' => [
+                    'default' => [
+                        'middleware' => [
+                            'my_middleware'  => 'some_middleware',
+                            'my_middleware2' => 'some_middleware',
+                        ]
+                    ]
                 ]
             ]
         ]);
@@ -41,13 +45,34 @@ class ConfigurationTest extends AbstractConfigurationTestCase
         $this->assertConfigurationIsInvalid(
             [
                 'tactician' => [
-                    'middlewares' => [
-                        'my_middleware'  => [],
-                        'my_middleware2' => 'some_middleware',
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'my_middleware'  => [],
+                                'my_middleware2' => 'some_middleware',
+                            ]
+                        ]
                     ]
                 ]
             ],
-            'Invalid type for path "tactician.middlewares.my_middleware". Expected scalar, but got array.'
+            'Invalid type for path "tactician.commandbus.default.middleware.my_middleware". Expected scalar, but got array.'
         );
+    }
+
+    public function testDefaultMiddlewareMustExist()
+    {
+        $this->assertConfigurationIsValid([
+            'tactician' => [
+                'default_bus' => 'foo',
+                'commandbus' => [
+                    'bar' => [
+                        'middleware' => [
+
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $this->markTestIncomplete('Not sure how to implement this with configuration invalidation.');
     }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -61,18 +61,66 @@ class ConfigurationTest extends AbstractConfigurationTestCase
 
     public function testDefaultMiddlewareMustExist()
     {
-        $this->assertConfigurationIsValid([
-            'tactician' => [
-                'default_bus' => 'foo',
-                'commandbus' => [
-                    'bar' => [
-                        'middleware' => [
-
+        $this->assertConfigurationIsInvalid(
+            [
+                'tactician' => [
+                    'default_bus' => 'foo',
+                    'commandbus' => [
+                        'bar' => [
+                            'middleware' => [
+                                'my_middleware'  => 'some_middleware',
+                            ]
                         ]
                     ]
                 ]
-            ]
-        ]);
-        $this->markTestIncomplete('Not sure how to implement this with configuration invalidation.');
+            ],
+            'The default_bus "foo" was not defined as command bus.'
+        );
+
+        $this->assertConfigurationIsInvalid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'bar' => [
+                            'middleware' => [
+                                'my_middleware'  => 'some_middleware',
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'The default_bus "default" was not defined as command bus.'
+        );
+    }
+
+    public function testMiddlewareDefinitionCannotBeEmpty()
+    {
+        $this->assertConfigurationIsInvalid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'The path "tactician.commandbus.default.middleware" should have at least 1 element(s) defined.'
+        );
+
+        $this->assertConfigurationIsInvalid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'foo' => [
+                            'middleware' => [
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'The path "tactician.commandbus.foo.middleware" should have at least 1 element(s) defined.'
+        );
     }
 }


### PR DESCRIPTION
Support for multiple command buses, as discussed in https://github.com/xtrasmal/TacticianBundle/issues/6
## Todo
- [x] Validate the config so it fails when default_bus does not exist
- [x] Validate the config so it fails when middleware array is empty
- [x] Documentation
