### PR TITLE
CommandHandler Middleware Validation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,8 +33,21 @@ class Configuration implements ConfigurationInterface
                                 ->requiresAtLeastOneElement()
                                 ->useAttributeAsKey('name')
                                 ->prototype('scalar')->end()
+                                ->validate()
+                                    ->ifTrue(function ($config) {
+                                        $isPresent = in_array('tactician.middleware.command_handler', $config);
+                                        $isLast    = end($config) == 'tactician.middleware.command_handler';
+                                        return ($isPresent && !$isLast);
+                                    })
+                                    ->thenInvalid(
+                                        '"tactician.middleware.command_handler" should be last loaded middleware'.
+                                        ' when it is use.'
+                                    )
+                                ->end()
                             ->end()
+
                         ->end()
+
                     ->end()
                 ->end()
                 ->scalarNode('default_bus')

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -123,4 +123,59 @@ class ConfigurationTest extends AbstractConfigurationTestCase
             'The path "tactician.commandbus.foo.middleware" should have at least 1 element(s) defined.'
         );
     }
+
+    public function testCommandHandlerMiddlewareIfPresentAndNotLastIsInvalid()
+    {
+        $this->assertConfigurationIsInvalid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'tactician.middleware.command_handler',
+                                'my_middleware.custom.stuff',
+
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '"tactician.middleware.command_handler" should be last loaded middleware when it is use.'
+        );
+    }
+
+    public function testCommandHandlerMiddlewarePresentAndLastIsValid()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'tactician.middleware.command_handler',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
+    }
+    public function testCommandHandlerMiddlewareNotPresentDoesNotAffectValidation()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                'tactician' => [
+                    'commandbus' => [
+                        'default' => [
+                            'middleware' => [
+                                'my_middleware.custom.stuff',
+                                'my_middleware.custom.other_stuff',
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Added extra validation to the Configuration Object to ensure that
the command_handler middleware is the last active middleware,
if it is present.

In case this middleware is not used, this validation is skipped.

Closes #12.
